### PR TITLE
feat: update YMapProvider interface

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -14,6 +14,7 @@ interface YMapProvider {
   query?: {
     lang?: 'tr_TR' | 'en_US' | 'en_RU' | 'ru_RU' | 'ru_UA' | 'uk_UA';
     apikey?: string;
+    suggest_apikey?: string;
     coordorder?: 'latlong' | 'longlat';
     load?: string;
     mode?: 'release' | 'debug';


### PR DESCRIPTION
there's a new query key "suggest_apikey" that is missing rn in the interface definition

https://yandex.ru/dev/jsapi-v2-1/doc/ru/v2-1/ref/reference/suggest

(english version of the docs has a typo in the example)